### PR TITLE
Update pyproject.toml Readme.md spelling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 ]
 
 requires-python = ">=3.11"
-readme = "README.md"
+readme = "Readme.md"
 license = { text = "APACHE 2.0" }
 
 [build-system]


### PR DESCRIPTION
If you do pdm install on the repository it fails, because of the readme field in pyproject.toml.

The file in the repo is "Readme.md" but the pyproject.toml refers to it as "README.md"